### PR TITLE
Add a Fuchas Zorya module.

### DIFF
--- a/zorya-modules/03_fuchasboot.lua
+++ b/zorya-modules/03_fuchasboot.lua
@@ -1,0 +1,24 @@
+-- 03_fuchasboot.lua
+-- Boots the Fuchas NT Kernel.
+local comp = component or require("component")
+local args = {...}
+local envs = args[1]
+for fs in comp.list("filesystem") do
+	if (comp.invoke(fs, "exists", "Fuchas/NT/boot.lua")) then
+		envs.boot[#envs.boot+1] = {"Fuchas NT on "..fs:sub(1, 3), "fuchas", fs, {}}
+	end
+end
+
+envs.hand["fuchas"] = function(fs, args)
+	computer.supportsOEFI = function()
+		return false
+	end
+	computer.supportsZorya = function()
+		return true
+	end
+	computer.getBootAddress = function() return fs end
+	loadfile = function(path)
+		return envs.loadfile(fs, path)
+	end
+	envs.loadfile(fs, "Fuchas/NT/boot.lua")(nil, table.unpack(args))
+end


### PR DESCRIPTION
This allows Fuchas to boot straight from the Zorya bootloader, but currently it has no OEFI support, as Zorya doesn't have any OEFI support yet. OEFI compatibility is planned in a future release.